### PR TITLE
Create and use local directories for SABnzbd downloads

### DIFF
--- a/modules/profiles/media-management/plex.nix
+++ b/modules/profiles/media-management/plex.nix
@@ -1,8 +1,12 @@
-{ lib, ... }: {
+{ config, lib, ... }: {
   services.plex = {
     enable = true;
     openFirewall = true;
   };
+
+  systemd.tmpfiles.rules = [
+    "d '/data/local/tmp/plex/transcode' 0777 ${config.services.plex.user} ${config.services.plex.group} - -"
+  ];
 
   e10.services.backup.jobs.system.exclude =
     lib.mkAfter [ "/var/lib/plex/Plex Media Server/Cache" ];

--- a/modules/profiles/media-management/sabnzbd.nix
+++ b/modules/profiles/media-management/sabnzbd.nix
@@ -1,6 +1,11 @@
-{
+{ config, ... }: {
   services.sabnzbd = {
     enable = true;
     openFirewall = true;
   };
+
+  systemd.tmpfiles.rules = [
+    "d '/data/local/tmp/sabnzbd/inter' 0777 ${config.services.sabnzbd.user} ${config.services.sabnzbd.group} - -"
+    "d '/data/local/tmp/sabnzbd/dst' 0777 ${config.services.sabnzbd.user} ${config.services.sabnzbd.group} - -"
+  ];
 }


### PR DESCRIPTION
Closes #63. Had to change the permissions that SABnzbd sets for files to `777` so Sonarr/Radarr could pick them up.